### PR TITLE
Erratum edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains code for reproducing results reported in our preprint o
 
 
 
-**Erratum** (updated Jan 2024): Despite careful checking, some errors and typos have made it into the published manuscript. 
+**Erratum**: Despite careful checking, some errors and typos have made it into the published manuscript. 
 We collect these errors [here](erratum/erratum.md).
 
 

--- a/erratum/erratum.md
+++ b/erratum/erratum.md
@@ -8,30 +8,36 @@ Thanks for reporting these problems. Our sincerest apologies that they made it i
 
 ## Incorrect equation for the decorrelation loss
 
-In the article, the decorrelation loss is described as "the sum of the squared off-diagonal terms of the covariance matrix between units". However, the expression provided in Eq. (6) was incorrectly written as:
+Thanks to Roy Urbach for pointing out the following discrepancy between our simulation code underlying the decorrelation loss and the corresponding mathematical expression in the Methods section.
+The mistake happened when transcribing our simulation in equations.
+Importantly, it does neither affect the results nor the conclusions of the study in any way.
+In the article, we introduced the decorrelation loss as "the sum of the squared off-diagonal terms of the covariance matrix between units" given
+by Eq. (6):
 
-$$\mathcal{L}_\mathrm{decorr}(t) = \frac{1}{(B-1)(M^2-M)}\sum_{b=1}^B\sum_{i=1}^M\sum_{k\neq i} (z_i^b(t)-\bar{z}_i(t))^2(z_k^b(t)-\bar{z}_k(t))^2,$$
+$$\L_\mathrm{decorr}(t) = \frac{1}{(B-1)(M^2-M)}\sum_{b=1}^B\sum_{i=1}^M\sum_{k\neq i} (z_i^b(t)-\bar{z}_i(t))^2(z_k^b(t)-\bar{z}_k(t))^2 \quad .$$ 
 
-whereas the correct expression is:
+which is incorrect. The correct expression is:
 
-$$\mathcal{L}_\mathrm{decorr}(t) = \frac{1}{4(M^2-M)}\sum_{i=1}^{M}\sum_{k\neq i}\left( \frac{\sum_{b=1}^B\left(z_i^b(t)-\bar{z}_i(t) \right) \left(z_k^b(t)-\bar{z}_k(t) \right)}{B-1}  \right)^2.$$
+$$L_\mathrm{decorr}(t) = \frac{1}{4(M^2-M)}\sum_{i=1}^{M}\sum_{k\neq i}\left( \frac{\sum_{b=1}^B\left(z_i^b(t)-\bar{z}_i(t) \right) \left(z_k^b(t)-\bar{z}_k(t) \right)}{B-1}  \right)^2 \quad .$$
 
-Consequently, the expressions for the learning rules in Eq. (7) in the article, and Eqs. (3) and (4) in the supplementary material are also incorrect. The corrected expressions for the learning rules are:
+Subsequently the learning rules in Eq. (7) in the article, and Eqs. (3) and (4) in the Supplementary Material, which where derived from the erroneous expression are also affected. 
+The corrected expressions for the learning rules are:
 
 $$\Delta W_{ij} = \eta\frac{1}{MB}\sum_{b=1}^B \biggl( -(z_i^b - z_i^b(t-\Delta t)) + \lambda_1\frac{\alpha}{\sigma_{i}^2}(z_i^b - \bar{z}_i) - \lambda_2\beta \sum_{k\neq i} (z_k^b - \bar{z}_k)C_{ik} \biggr) f'(a_i^b)x_j^b - \eta \eta_w W_{ij}$$
 
-$$ \frac{\partial \mathcal{L}_{\mathrm{decorr}}}{\partial W_{ij}} = \frac{1}{(B-1)(M^2-M)} \sum_{b=1}^B f'(a_i^b)x_j^b \sum_{k\neq i}\left(z_k^b(t)-\bar{z}_k(t)\right)  C_{ik},$$
+and
 
+$$ \frac{\partial L_{\mathrm{decorr}}}{\partial W_{ij}} = \frac{1}{(B-1)(M^2-M)} \sum_{b=1}^B f'(a_i^b)x_j^b \sum_{k\neq i}\left(z_k^b(t)-\bar{z}_k(t)\right)  C_{ik},$$
 where $C_{ik}$ is the covariance matrix between units $i$ and $k$:
 
 $$C_{ik} = \frac{1}{B-1}\sum_{b=1}^B \left(z_i^b(t)-\bar{z}_i(t)\right)\left(z_k^b(t)-\bar{z}_k(t)\right).$$
 
-The corrected equations are the ones that were used in the simulations and the results presented in the article. This form of the decorrelation objective was proposed in VICReg, and is typically used in Self-Supervised Learning. The incorrect form of the decorrelation loss was a mistake made during the writing of the article. Since the decorrelation objective was only used as a convenient way to enforce decorrelation, the error does not affect the results or conclusions of the article. We apologize for the confusion caused by this error, and will be publishing an erratum to correct this in the article.
+We apologize for any confusion caused by this oversight.
+
 
 # Spiking Network Simulations
 
 Thanks to Github user [yilun-wu](https://github.com/yilun-wu), who made us aware of a few small discrepancies between our simulation code and its description in the methods (Issues [#2](https://github.com/fmi-basel/latent-predictive-learning/issues/2), [#3](https://github.com/fmi-basel/latent-predictive-learning/issues/3), [#4](https://github.com/fmi-basel/latent-predictive-learning/issues/4), and [#5](https://github.com/fmi-basel/latent-predictive-learning/issues/5)).
-.
 
 
 ## Implementation of transmitter triggered plasticity ([Issue #2](https://github.com/fmi-basel/latent-predictive-learning/issues/2))

--- a/erratum/erratum.md
+++ b/erratum/erratum.md
@@ -4,6 +4,29 @@ Here we keep track of typos and errors that have been reported to us by the atte
 
 Thanks for reporting these problems. Our sincerest apologies that they made it into the final manuscript.
 
+# Deep Learning Simulations
+
+## Incorrect equation for the decorrelation loss
+
+In the article, the decorrelation loss is described as "the sum of the squared off-diagonal terms of the covariance matrix between units". However, the expression provided in Eq. (6) was incorrectly written as:
+
+$$\mathcal{L}_\mathrm{decorr}(t) = \frac{1}{(B-1)(M^2-M)}\sum_{b=1}^B\sum_{i=1}^M\sum_{k\neq i} (z_i^b(t)-\bar{z}_i(t))^2(z_k^b(t)-\bar{z}_k(t))^2,$$
+
+whereas the correct expression is:
+
+$$\mathcal{L}_\mathrm{decorr}(t) = \frac{1}{4(M^2-M)}\sum_{i=1}^{M}\sum_{k\neq i}\left( \frac{\sum_{b=1}^B\left(z_i^b(t)-\bar{z}_i(t) \right) \left(z_k^b(t)-\bar{z}_k(t) \right)}{B-1}  \right)^2.$$
+
+Consequently, the expressions for the learning rules in Eq. (7) in the article, and Eqs. (3) and (4) in the supplementary material are also incorrect. The corrected expressions for the learning rules are:
+
+$$\Delta W_{ij} = \eta\frac{1}{MB}\sum_{b=1}^B \biggl( -(z_i^b - z_i^b(t-\Delta t)) + \lambda_1\frac{\alpha}{\sigma_{i}^2}(z_i^b - \bar{z}_i) - \lambda_2\beta \sum_{k\neq i} (z_k^b - \bar{z}_k)C_{ik} \biggr) f'(a_i^b)x_j^b - \eta \eta_w W_{ij}$$
+
+$$ \frac{\partial \mathcal{L}_{\mathrm{decorr}}}{\partial W_{ij}} = \frac{1}{(B-1)(M^2-M)} \sum_{b=1}^B f'(a_i^b)x_j^b \sum_{k\neq i}\left(z_k^b(t)-\bar{z}_k(t)\right)  C_{ik},$$
+
+where $C_{ik}$ is the covariance matrix between units $i$ and $k$:
+
+$$C_{ik} = \frac{1}{B-1}\sum_{b=1}^B \left(z_i^b(t)-\bar{z}_i(t)\right)\left(z_k^b(t)-\bar{z}_k(t)\right).$$
+
+The corrected equations are the ones that were used in the simulations and the results presented in the article. This form of the decorrelation objective was proposed in VICReg, and is typically used in Self-Supervised Learning. The incorrect form of the decorrelation loss was a mistake made during the writing of the article. Since the decorrelation objective was only used as a convenient way to enforce decorrelation, the error does not affect the results or conclusions of the article. We apologize for the confusion caused by this error, and will be publishing an erratum to correct this in the article.
 
 # Spiking Network Simulations
 

--- a/erratum/erratum.md
+++ b/erratum/erratum.md
@@ -14,7 +14,7 @@ Importantly, it does neither affect the results nor the conclusions of the study
 In the article, we introduced the decorrelation loss as "the sum of the squared off-diagonal terms of the covariance matrix between units" given
 by Eq. (6):
 
-$$\L_\mathrm{decorr}(t) = \frac{1}{(B-1)(M^2-M)}\sum_{b=1}^B\sum_{i=1}^M\sum_{k\neq i} (z_i^b(t)-\bar{z}_i(t))^2(z_k^b(t)-\bar{z}_k(t))^2 \quad .$$ 
+$$L_\mathrm{decorr}(t) = \frac{1}{(B-1)(M^2-M)}\sum_{b=1}^B\sum_{i=1}^M\sum_{k\neq i} (z_i^b(t)-\bar{z}_i(t))^2(z_k^b(t)-\bar{z}_k(t))^2 \quad .$$ 
 
 which is incorrect. The correct expression is:
 


### PR DESCRIPTION
I am adding several small text changes. Let's use this branch to finalize the update to the erratum. 

I noticed that the equations are not correctly rendering in Markdown which we should fix. Removing the \mathcal command allowed me to get about half of them working. 